### PR TITLE
Implicit Usage of ExpectPlatform impls

### DIFF
--- a/src/main/kotlin/me/shedaniel/architectury/idea/insight/ExpectPlatformImplicitUsageProvider.kt
+++ b/src/main/kotlin/me/shedaniel/architectury/idea/insight/ExpectPlatformImplicitUsageProvider.kt
@@ -1,0 +1,33 @@
+package me.shedaniel.architectury.idea.insight
+
+import com.intellij.codeInsight.daemon.ImplicitUsageProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiParameter
+import me.shedaniel.architectury.idea.util.commonMethods
+import me.shedaniel.architectury.idea.util.isCommonExpectPlatform
+import me.shedaniel.architectury.idea.util.platformMethods
+
+class ExpectPlatformImplicitUsageProvider : ImplicitUsageProvider {
+    override fun isImplicitUsage(element: PsiElement): Boolean {
+        // if the method is implementing a common ExpectPlatform method mark it as used
+        if (element is PsiMethod) {
+            return element.commonMethods.isNotEmpty()
+        }
+
+        // if the method is annotated with ExpectPlatform or implements an ExpectPlatform method,
+        // mark all of its parameters as used.
+        if (element is PsiParameter) {
+            // the method is the parent's parent
+            val parent = element.parent.parent
+
+            return parent is PsiMethod && (parent.isCommonExpectPlatform || parent.commonMethods.isNotEmpty())
+        }
+
+        return false
+    }
+
+    override fun isImplicitRead(element: PsiElement): Boolean = false
+
+    override fun isImplicitWrite(element: PsiElement): Boolean = false
+}

--- a/src/main/kotlin/me/shedaniel/architectury/idea/insight/ExpectPlatformImplicitUsageProvider.kt
+++ b/src/main/kotlin/me/shedaniel/architectury/idea/insight/ExpectPlatformImplicitUsageProvider.kt
@@ -6,7 +6,6 @@ import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
 import me.shedaniel.architectury.idea.util.commonMethods
 import me.shedaniel.architectury.idea.util.isCommonExpectPlatform
-import me.shedaniel.architectury.idea.util.platformMethods
 
 class ExpectPlatformImplicitUsageProvider : ImplicitUsageProvider {
     override fun isImplicitUsage(element: PsiElement): Boolean {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -25,6 +25,8 @@
                          enabledByDefault="true"
                          level="WARNING"
                          implementationClass="me.shedaniel.architectury.idea.inspection.UnimplementedExpectPlatformInspection"/>
+
+        <implicitUsageProvider implementation="me.shedaniel.architectury.idea.insight.ExpectPlatformImplicitUsageProvider"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
Adds an ImplicitUsageProvider to mark implementing methods as used, and all parameters involved as used (same behavior as if it was being overridden normally)
![A picture's worth a thousand words](https://cdn.discordapp.com/attachments/797446463034359838/821433811837124638/unknown.png)