### PR TITLE
Add Kotlin support for gutter icons

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
     version = "2021.1"
-    setPlugins("Kotlin", "java")
+    setPlugins("java", "Kotlin")
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
     version = "2021.1"
-    setPlugins("java")
+    setPlugins("Kotlin", "java")
 }
 
 tasks {

--- a/src/main/kotlin/me/shedaniel/architectury/idea/gutter/CommonMethodLineMarkerProvider.kt
+++ b/src/main/kotlin/me/shedaniel/architectury/idea/gutter/CommonMethodLineMarkerProvider.kt
@@ -1,52 +1,15 @@
 package me.shedaniel.architectury.idea.gutter
 
-import com.intellij.codeInsight.daemon.DefaultGutterIconNavigationHandler
-import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
-import com.intellij.codeInsight.daemon.LineMarkerInfo
-import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
 import com.intellij.icons.AllIcons
-import com.intellij.openapi.editor.markup.GutterIconRenderer
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiIdentifier
 import com.intellij.psi.PsiMethod
-import me.shedaniel.architectury.idea.util.ArchitecturyBundle
 import me.shedaniel.architectury.idea.util.platformMethods
-import java.awt.event.MouseEvent
 import javax.swing.Icon
 
-class CommonMethodLineMarkerProvider : LineMarkerProviderDescriptor(), GutterIconNavigationHandler<PsiIdentifier> {
+class CommonMethodLineMarkerProvider : JavaRelatedMethodLineMarkerProvider() {
+    override val tooltipTranslationKey = "architectury.gutter.goToPlatform"
+    override val navTitleTranslationKey = "architectury.gutter.chooseImpl"
+    override val PsiMethod.relatedMethods: Set<PsiMethod> get() = platformMethods
+
     override fun getName(): String = "ExpectPlatform line marker"
     override fun getIcon(): Icon = AllIcons.Gutter.ImplementedMethod
-
-    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<PsiIdentifier>? {
-        if (element is PsiIdentifier) {
-            val parent = element.parent
-
-            if (parent is PsiMethod && parent.nameIdentifier === element && parent.platformMethods.isNotEmpty()) {
-                return LineMarkerInfo(
-                    element,
-                    element.textRange,
-                    icon,
-                    { ArchitecturyBundle["architectury.gutter.goToPlatform"] },
-                    this,
-                    GutterIconRenderer.Alignment.LEFT,
-                    { ArchitecturyBundle["architectury.gutter.goToPlatform"] }
-                )
-            }
-        }
-
-        return null
-    }
-
-    override fun navigate(e: MouseEvent, elt: PsiIdentifier) {
-        val method = elt.parent as? PsiMethod ?: return
-        val implementations = method.platformMethods
-
-        if (implementations.isNotEmpty()) {
-            DefaultGutterIconNavigationHandler<PsiIdentifier>(
-                implementations,
-                "<html>" + ArchitecturyBundle["architectury.gutter.chooseImpl", "<b>${method.name}</b>", implementations.size]
-            ).navigate(e, elt)
-        }
-    }
 }

--- a/src/main/kotlin/me/shedaniel/architectury/idea/gutter/JavaRelatedMethodLineMarkerProvider.kt
+++ b/src/main/kotlin/me/shedaniel/architectury/idea/gutter/JavaRelatedMethodLineMarkerProvider.kt
@@ -1,0 +1,9 @@
+package me.shedaniel.architectury.idea.gutter
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+
+abstract class JavaRelatedMethodLineMarkerProvider : RelatedMethodLineMarkerProvider<PsiMethod>(PsiMethod::class.java) {
+    override val PsiMethod.methodName: String get() = name
+    override val PsiMethod.methodNameIdentifier: PsiElement get() = nameIdentifier!!
+}

--- a/src/main/kotlin/me/shedaniel/architectury/idea/gutter/PlatformMethodLineMarkerProvider.kt
+++ b/src/main/kotlin/me/shedaniel/architectury/idea/gutter/PlatformMethodLineMarkerProvider.kt
@@ -1,52 +1,15 @@
 package me.shedaniel.architectury.idea.gutter
 
-import com.intellij.codeInsight.daemon.DefaultGutterIconNavigationHandler
-import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
-import com.intellij.codeInsight.daemon.LineMarkerInfo
-import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
 import com.intellij.icons.AllIcons
-import com.intellij.openapi.editor.markup.GutterIconRenderer
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiIdentifier
 import com.intellij.psi.PsiMethod
-import me.shedaniel.architectury.idea.util.ArchitecturyBundle
 import me.shedaniel.architectury.idea.util.commonMethods
-import java.awt.event.MouseEvent
 import javax.swing.Icon
 
-class PlatformMethodLineMarkerProvider : LineMarkerProviderDescriptor(), GutterIconNavigationHandler<PsiIdentifier> {
+class PlatformMethodLineMarkerProvider : JavaRelatedMethodLineMarkerProvider() {
+    override val tooltipTranslationKey = "architectury.gutter.goToCommon"
+    override val navTitleTranslationKey = "architectury.gutter.chooseCommon"
+    override val PsiMethod.relatedMethods: Set<PsiMethod> get() = commonMethods
+
     override fun getName(): String = "Platform implementation method line marker"
     override fun getIcon(): Icon = AllIcons.Gutter.ImplementingMethod
-
-    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<PsiIdentifier>? {
-        if (element is PsiIdentifier) {
-            val parent = element.parent
-
-            if (parent is PsiMethod && parent.nameIdentifier === element && parent.commonMethods.isNotEmpty()) {
-                return LineMarkerInfo(
-                    element,
-                    element.textRange,
-                    icon,
-                    { ArchitecturyBundle["architectury.gutter.goToCommon"] },
-                    this,
-                    GutterIconRenderer.Alignment.LEFT,
-                    { ArchitecturyBundle["architectury.gutter.goToCommon"] }
-                )
-            }
-        }
-
-        return null
-    }
-
-    override fun navigate(e: MouseEvent, elt: PsiIdentifier) {
-        val method = elt.parent as? PsiMethod ?: return
-        val commonMethods = method.commonMethods
-
-        if (commonMethods.isNotEmpty()) {
-            DefaultGutterIconNavigationHandler<PsiIdentifier>(
-                commonMethods,
-                "<html>" + ArchitecturyBundle["architectury.gutter.chooseCommon", "<b>${method.name}</b>", commonMethods.size]
-            ).navigate(e, elt)
-        }
-    }
 }

--- a/src/main/kotlin/me/shedaniel/architectury/idea/gutter/RelatedMethodLineMarkerProvider.kt
+++ b/src/main/kotlin/me/shedaniel/architectury/idea/gutter/RelatedMethodLineMarkerProvider.kt
@@ -1,0 +1,55 @@
+package me.shedaniel.architectury.idea.gutter
+
+import com.intellij.codeInsight.daemon.DefaultGutterIconNavigationHandler
+import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.util.PsiTreeUtil
+import me.shedaniel.architectury.idea.util.ArchitecturyBundle
+import java.awt.event.MouseEvent
+import javax.swing.Icon
+
+abstract class RelatedMethodLineMarkerProvider<M : PsiElement>(
+    private val parentType: Class<M>
+) : LineMarkerProviderDescriptor(), GutterIconNavigationHandler<PsiElement> {
+    protected abstract val tooltipTranslationKey: String
+    protected abstract val navTitleTranslationKey: String
+
+    protected abstract val M.relatedMethods: Set<PsiMethod>
+    protected abstract val M.methodName: String
+    protected abstract val M.methodNameIdentifier: PsiElement
+
+    abstract override fun getIcon(): Icon
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<PsiElement>? {
+        if (parentType.isInstance(element) && (element as M).relatedMethods.isNotEmpty()) {
+            return LineMarkerInfo(
+                element.methodNameIdentifier,
+                element.methodNameIdentifier.textRange,
+                icon,
+                { ArchitecturyBundle[tooltipTranslationKey] },
+                this,
+                GutterIconRenderer.Alignment.LEFT,
+                { ArchitecturyBundle[tooltipTranslationKey] }
+            )
+        }
+
+        return null
+    }
+
+    override fun navigate(e: MouseEvent, elt: PsiElement) {
+        val method = PsiTreeUtil.getParentOfType(elt, parentType) ?: return
+        val related = method.relatedMethods
+
+        if (related.isNotEmpty()) {
+            DefaultGutterIconNavigationHandler<PsiElement>(
+                related,
+                "<html>" + ArchitecturyBundle[navTitleTranslationKey, "<b>${method.methodName}</b>", related.size]
+            ).navigate(e, elt)
+        }
+    }
+}

--- a/src/main/kotlin/me/shedaniel/architectury/idea/kotlin/README.md
+++ b/src/main/kotlin/me/shedaniel/architectury/idea/kotlin/README.md
@@ -1,0 +1,8 @@
+This directory contains the (partial) Kotlin support code
+in the Architectury IDEA plugin.
+
+Some things you might want to note here:
+
+- IDEA reports errors when you call the Kotlin plugin's functions
+  that have standard PSI types in their signature. I have no clue why.
+- Kotlin PSI element -> Java PSI element: use `LightClassUtil`

--- a/src/main/kotlin/me/shedaniel/architectury/idea/kotlin/gutter/CommonFunctionLineMarkerProvider.kt
+++ b/src/main/kotlin/me/shedaniel/architectury/idea/kotlin/gutter/CommonFunctionLineMarkerProvider.kt
@@ -1,48 +1,16 @@
 package me.shedaniel.architectury.idea.kotlin.gutter
 
-import com.intellij.codeInsight.daemon.DefaultGutterIconNavigationHandler
-import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
-import com.intellij.codeInsight.daemon.LineMarkerInfo
-import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
 import com.intellij.icons.AllIcons
-import com.intellij.openapi.editor.markup.GutterIconRenderer
-import com.intellij.psi.PsiElement
-import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.PsiMethod
 import me.shedaniel.architectury.idea.kotlin.util.platformMethods
-import me.shedaniel.architectury.idea.util.ArchitecturyBundle
 import org.jetbrains.kotlin.psi.KtNamedFunction
-import java.awt.event.MouseEvent
 import javax.swing.Icon
 
-class CommonFunctionLineMarkerProvider : LineMarkerProviderDescriptor(), GutterIconNavigationHandler<PsiElement> {
+class CommonFunctionLineMarkerProvider : KotlinRelatedMethodLineMarkerProvider() {
+    override val tooltipTranslationKey = "architectury.gutter.goToPlatform"
+    override val navTitleTranslationKey = "architectury.gutter.chooseImpl"
+    override val KtNamedFunction.relatedMethods: Set<PsiMethod> get() = platformMethods
+
     override fun getName(): String = "ExpectPlatform line marker (Kotlin)"
     override fun getIcon(): Icon = AllIcons.Gutter.ImplementedMethod
-
-    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<PsiElement>? {
-        if (element is KtNamedFunction && element.platformMethods.isNotEmpty()) {
-            return LineMarkerInfo(
-                element.nameIdentifier!!,
-                element.nameIdentifier!!.textRange,
-                icon,
-                { ArchitecturyBundle["architectury.gutter.goToPlatform"] },
-                this,
-                GutterIconRenderer.Alignment.LEFT,
-                { ArchitecturyBundle["architectury.gutter.goToPlatform"] }
-            )
-        }
-
-        return null
-    }
-
-    override fun navigate(e: MouseEvent, elt: PsiElement) {
-        val fn = PsiTreeUtil.getParentOfType(elt, KtNamedFunction::class.java) ?: return
-        val implementations = fn.platformMethods
-
-        if (implementations.isNotEmpty()) {
-            DefaultGutterIconNavigationHandler<PsiElement>(
-                implementations,
-                "<html>" + ArchitecturyBundle["architectury.gutter.chooseImpl", "<b>${fn.name}</b>", implementations.size]
-            ).navigate(e, elt)
-        }
-    }
 }

--- a/src/main/kotlin/me/shedaniel/architectury/idea/kotlin/gutter/CommonFunctionLineMarkerProvider.kt
+++ b/src/main/kotlin/me/shedaniel/architectury/idea/kotlin/gutter/CommonFunctionLineMarkerProvider.kt
@@ -1,0 +1,48 @@
+package me.shedaniel.architectury.idea.kotlin.gutter
+
+import com.intellij.codeInsight.daemon.DefaultGutterIconNavigationHandler
+import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import me.shedaniel.architectury.idea.kotlin.util.platformMethods
+import me.shedaniel.architectury.idea.util.ArchitecturyBundle
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import java.awt.event.MouseEvent
+import javax.swing.Icon
+
+class CommonFunctionLineMarkerProvider : LineMarkerProviderDescriptor(), GutterIconNavigationHandler<PsiElement> {
+    override fun getName(): String = "ExpectPlatform line marker (Kotlin)"
+    override fun getIcon(): Icon = AllIcons.Gutter.ImplementedMethod
+
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<PsiElement>? {
+        if (element is KtNamedFunction && element.platformMethods.isNotEmpty()) {
+            return LineMarkerInfo(
+                element.nameIdentifier!!,
+                element.nameIdentifier!!.textRange,
+                icon,
+                { ArchitecturyBundle["architectury.gutter.goToPlatform"] },
+                this,
+                GutterIconRenderer.Alignment.LEFT,
+                { ArchitecturyBundle["architectury.gutter.goToPlatform"] }
+            )
+        }
+
+        return null
+    }
+
+    override fun navigate(e: MouseEvent, elt: PsiElement) {
+        val fn = PsiTreeUtil.getParentOfType(elt, KtNamedFunction::class.java) ?: return
+        val implementations = fn.platformMethods
+
+        if (implementations.isNotEmpty()) {
+            DefaultGutterIconNavigationHandler<PsiElement>(
+                implementations,
+                "<html>" + ArchitecturyBundle["architectury.gutter.chooseImpl", "<b>${fn.name}</b>", implementations.size]
+            ).navigate(e, elt)
+        }
+    }
+}

--- a/src/main/kotlin/me/shedaniel/architectury/idea/kotlin/gutter/KotlinRelatedMethodLineMarkerProvider.kt
+++ b/src/main/kotlin/me/shedaniel/architectury/idea/kotlin/gutter/KotlinRelatedMethodLineMarkerProvider.kt
@@ -1,0 +1,10 @@
+package me.shedaniel.architectury.idea.kotlin.gutter
+
+import com.intellij.psi.PsiElement
+import me.shedaniel.architectury.idea.gutter.RelatedMethodLineMarkerProvider
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+abstract class KotlinRelatedMethodLineMarkerProvider : RelatedMethodLineMarkerProvider<KtNamedFunction>(KtNamedFunction::class.java) {
+    override val KtNamedFunction.methodName: String get() = name!!
+    override val KtNamedFunction.methodNameIdentifier: PsiElement get() = nameIdentifier!!
+}

--- a/src/main/kotlin/me/shedaniel/architectury/idea/kotlin/gutter/PlatformFunctionLineMarkerProvider.kt
+++ b/src/main/kotlin/me/shedaniel/architectury/idea/kotlin/gutter/PlatformFunctionLineMarkerProvider.kt
@@ -1,0 +1,48 @@
+package me.shedaniel.architectury.idea.kotlin.gutter
+
+import com.intellij.codeInsight.daemon.DefaultGutterIconNavigationHandler
+import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import me.shedaniel.architectury.idea.kotlin.util.commonMethods
+import me.shedaniel.architectury.idea.util.ArchitecturyBundle
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import java.awt.event.MouseEvent
+import javax.swing.Icon
+
+class PlatformFunctionLineMarkerProvider : LineMarkerProviderDescriptor(), GutterIconNavigationHandler<PsiElement> {
+    override fun getName(): String = "Platform implementation method line marker (Kotlin)"
+    override fun getIcon(): Icon = AllIcons.Gutter.ImplementingMethod
+
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<PsiElement>? {
+        if (element is KtNamedFunction && element.commonMethods.isNotEmpty()) {
+            return LineMarkerInfo(
+                element.nameIdentifier!!,
+                element.nameIdentifier!!.textRange,
+                icon,
+                { ArchitecturyBundle["architectury.gutter.goToCommon"] },
+                this,
+                GutterIconRenderer.Alignment.LEFT,
+                { ArchitecturyBundle["architectury.gutter.goToCommon"] }
+            )
+        }
+
+        return null
+    }
+
+    override fun navigate(e: MouseEvent, elt: PsiElement) {
+        val fn = PsiTreeUtil.getParentOfType(elt, KtNamedFunction::class.java) ?: return
+        val commonMethods = fn.commonMethods
+
+        if (commonMethods.isNotEmpty()) {
+            DefaultGutterIconNavigationHandler<PsiElement>(
+                commonMethods,
+                "<html>" + ArchitecturyBundle["architectury.gutter.chooseCommon", "<b>${fn.name}</b>", commonMethods.size]
+            ).navigate(e, elt)
+        }
+    }
+}

--- a/src/main/kotlin/me/shedaniel/architectury/idea/kotlin/gutter/PlatformFunctionLineMarkerProvider.kt
+++ b/src/main/kotlin/me/shedaniel/architectury/idea/kotlin/gutter/PlatformFunctionLineMarkerProvider.kt
@@ -1,48 +1,16 @@
 package me.shedaniel.architectury.idea.kotlin.gutter
 
-import com.intellij.codeInsight.daemon.DefaultGutterIconNavigationHandler
-import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
-import com.intellij.codeInsight.daemon.LineMarkerInfo
-import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
 import com.intellij.icons.AllIcons
-import com.intellij.openapi.editor.markup.GutterIconRenderer
-import com.intellij.psi.PsiElement
-import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.PsiMethod
 import me.shedaniel.architectury.idea.kotlin.util.commonMethods
-import me.shedaniel.architectury.idea.util.ArchitecturyBundle
 import org.jetbrains.kotlin.psi.KtNamedFunction
-import java.awt.event.MouseEvent
 import javax.swing.Icon
 
-class PlatformFunctionLineMarkerProvider : LineMarkerProviderDescriptor(), GutterIconNavigationHandler<PsiElement> {
+class PlatformFunctionLineMarkerProvider : KotlinRelatedMethodLineMarkerProvider() {
+    override val tooltipTranslationKey = "architectury.gutter.goToCommon"
+    override val navTitleTranslationKey = "architectury.gutter.chooseCommon"
+    override val KtNamedFunction.relatedMethods: Set<PsiMethod> get() = commonMethods
+
     override fun getName(): String = "Platform implementation method line marker (Kotlin)"
     override fun getIcon(): Icon = AllIcons.Gutter.ImplementingMethod
-
-    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<PsiElement>? {
-        if (element is KtNamedFunction && element.commonMethods.isNotEmpty()) {
-            return LineMarkerInfo(
-                element.nameIdentifier!!,
-                element.nameIdentifier!!.textRange,
-                icon,
-                { ArchitecturyBundle["architectury.gutter.goToCommon"] },
-                this,
-                GutterIconRenderer.Alignment.LEFT,
-                { ArchitecturyBundle["architectury.gutter.goToCommon"] }
-            )
-        }
-
-        return null
-    }
-
-    override fun navigate(e: MouseEvent, elt: PsiElement) {
-        val fn = PsiTreeUtil.getParentOfType(elt, KtNamedFunction::class.java) ?: return
-        val commonMethods = fn.commonMethods
-
-        if (commonMethods.isNotEmpty()) {
-            DefaultGutterIconNavigationHandler<PsiElement>(
-                commonMethods,
-                "<html>" + ArchitecturyBundle["architectury.gutter.chooseCommon", "<b>${fn.name}</b>", commonMethods.size]
-            ).navigate(e, elt)
-        }
-    }
 }

--- a/src/main/kotlin/me/shedaniel/architectury/idea/kotlin/util/KotlinPlatformUtil.kt
+++ b/src/main/kotlin/me/shedaniel/architectury/idea/kotlin/util/KotlinPlatformUtil.kt
@@ -1,0 +1,24 @@
+package me.shedaniel.architectury.idea.kotlin.util
+
+import com.intellij.psi.PsiMethod
+import me.shedaniel.architectury.idea.util.commonMethods
+import me.shedaniel.architectury.idea.util.platformMethods
+import org.jetbrains.kotlin.asJava.LightClassUtil
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+/**
+ * Gets a "light class" version of this Kotlin function as a Java PSI method.
+ */
+fun KtNamedFunction.toPsiMethod(): PsiMethod? = LightClassUtil.getLightClassMethod(this)
+
+/**
+ * The common declarations corresponding to this platform method.
+ */
+val KtNamedFunction.commonMethods: Set<PsiMethod>
+    get() = toPsiMethod()?.commonMethods ?: emptySet()
+
+/**
+ * The platform implementations of this common method.
+ */
+val KtNamedFunction.platformMethods: Set<PsiMethod>
+    get() = toPsiMethod()?.platformMethods ?: emptySet()

--- a/src/main/kotlin/me/shedaniel/architectury/idea/util/PlatformUtil.kt
+++ b/src/main/kotlin/me/shedaniel/architectury/idea/util/PlatformUtil.kt
@@ -37,17 +37,17 @@ fun PsiMethod.findAnnotation(type: AnnotationType): PsiAnnotation? =
 /**
  * The common declarations corresponding to this platform method.
  */
-val PsiMethod.commonMethods: List<PsiMethod>
+val PsiMethod.commonMethods: Set<PsiMethod>
     get() {
         // no common methods for non-statics
-        if (!isStatic) return emptyList()
+        if (!isStatic) return emptySet()
 
-        val clazz = containingClass ?: return emptyList()
-        val name = clazz.binaryName ?: return emptyList()
+        val clazz = containingClass ?: return emptySet()
+        val name = clazz.binaryName ?: return emptySet()
         val pkg = name.substringBeforeLast('.')
 
         val nameMatches = name.endsWith("Impl") && Platform.values().any { pkg.endsWith(".${it.id}") }
-        if (!nameMatches) return emptyList()
+        if (!nameMatches) return emptySet()
 
         val commonPkg = pkg.substringBeforeLast('.')
         val commonClassName = name.substringAfterLast('.').removeSuffix("Impl")
@@ -62,14 +62,14 @@ val PsiMethod.commonMethods: List<PsiMethod>
                 it.findMethodBySignature(this, false)
             }
             ?.filter { it.isCommonExpectPlatform }
-            ?.toList()
-            ?: emptyList()
+            ?.toSet()
+            ?: emptySet()
     }
 
 /**
  * The platform implementations of this common method.
  */
-val PsiMethod.platformMethodsByPlatform: Map<Platform, List<PsiMethod>>
+val PsiMethod.platformMethodsByPlatform: Map<Platform, Set<PsiMethod>>
     get() {
         if (!isCommonExpectPlatform) return emptyMap()
         val clazz = containingClass ?: return emptyMap()
@@ -83,15 +83,15 @@ val PsiMethod.platformMethodsByPlatform: Map<Platform, List<PsiMethod>>
                 .mapNotNull { clazz ->
                     clazz.findMethodBySignature(this, false)
                 }
-                .toList()
+                .toSet()
         }
     }
 
 /**
  * The platform implementations of this common method.
  */
-val PsiMethod.platformMethods: Collection<PsiMethod>
-    get() = platformMethodsByPlatform.flatMap { (_, methods) -> methods }
+val PsiMethod.platformMethods: Set<PsiMethod>
+    get() = platformMethodsByPlatform.flatMap { (_, methods) -> methods }.toSet()
 
 /**
  * The platforms for this `@PlatformOnly` method, or null if this method

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,10 +17,13 @@
     <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
     <depends>com.intellij.modules.java</depends>
+    <depends>org.jetbrains.kotlin</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <codeInsight.lineMarkerProvider language="JAVA" implementationClass="me.shedaniel.architectury.idea.gutter.CommonMethodLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="JAVA" implementationClass="me.shedaniel.architectury.idea.gutter.PlatformMethodLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="kotlin" implementationClass="me.shedaniel.architectury.idea.kotlin.gutter.CommonFunctionLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="kotlin" implementationClass="me.shedaniel.architectury.idea.kotlin.gutter.PlatformFunctionLineMarkerProvider"/>
 
         <localInspection language="JAVA"
                          displayName="Unimplemented @ExpectPlatform method"


### PR DESCRIPTION
Probably needs some code cleanup (can the shared logic between the four `LineMarkerProvider`s be abstracted?)